### PR TITLE
Wrong domain name

### DIFF
--- a/domains.txt
+++ b/domains.txt
@@ -1,5 +1,5 @@
 zh.wikipedia.org
-jp.wikipedia.org
+ja.wikipedia.org
 www.pixiv.net
 pixiv.net
 accounts.pixiv.net


### PR DESCRIPTION
Domain name for Japanese Wikipedia is ja.wikipedia.org