### PR TITLE
add sites and change dnscrypt config

### DIFF
--- a/dnscrypt/dnscrypt-proxy.toml
+++ b/dnscrypt/dnscrypt-proxy.toml
@@ -496,7 +496,7 @@ cache_neg_max_ttl = 600
   ## An example of a remote source from https://github.com/DNSCrypt/dnscrypt-resolvers
 
   [sources.'public-resolvers']
-  urls = ['https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md']
+  urls = ['https://cdn.jsdelivr.net/gh/DNSCrypt/dnscrypt-resolvers/v2/public-resolvers.md','https://cdn.statically.io/gh/DNSCrypt/dnscrypt-resolvers/master/v2/public-resolvers.md','https://ghcdn.rawgit.org/DNSCrypt/dnscrypt-resolvers/master/v2/public-resolvers.md','https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md']
   cache_file = 'public-resolvers.md'
   minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
   refresh_delay = 72

--- a/dnscrypt/dnscrypt-proxy.toml
+++ b/dnscrypt/dnscrypt-proxy.toml
@@ -185,7 +185,7 @@ cert_refresh_delay = 240
 ## People in China may need to use 114.114.114.114:53 here.
 ## Other popular options include 8.8.8.8 and 1.1.1.1.
 
-fallback_resolver = '9.9.9.9:53'
+fallback_resolver = '119.29.29.29:53'
 
 
 ## Never let dnscrypt-proxy try to use the system DNS settings;
@@ -496,7 +496,7 @@ cache_neg_max_ttl = 600
   ## An example of a remote source from https://github.com/DNSCrypt/dnscrypt-resolvers
 
   [sources.'public-resolvers']
-  urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v2/public-resolvers.md', 'https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md']
+  urls = ['https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md']
   cache_file = 'public-resolvers.md'
   minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
   refresh_delay = 72

--- a/template/pac
+++ b/template/pac
@@ -34,7 +34,9 @@ var domains = {
   "google.com.hk": 1,
   "mega.nz": 1,
   "nytimes.com": 1,
-  "archiveofourown.org": 1
+  "archiveofourown.org": 1,
+  "e-hentai.org": 1,
+  "exhentai.org": 1
 };
 
 var shexps = {


### PR DESCRIPTION
9.9.9.9 在部分网络连通性差，更换为 DNSPod
raw.githubusercontent.com 已被污染，删除以直接请求后一个可用的源
添加最近被 SNI 阻断的站点