### PR TITLE
Update dnscrypt-proxy.toml

### DIFF
--- a/dnscrypt/dnscrypt-proxy.toml
+++ b/dnscrypt/dnscrypt-proxy.toml
@@ -30,7 +30,7 @@
 # server_names = ['scaleway-fr', 'google', 'yandex', 'cloudflare']
 
 
-listen_addresses = ['[::]:53000']
+listen_addresses = ['127.0.0.1:53000', '[::1]:53000']
 
 
 ## Maximum number of simultaneous client connections to accept

--- a/dnscrypt/dnscrypt-proxy.toml
+++ b/dnscrypt/dnscrypt-proxy.toml
@@ -30,10 +30,7 @@
 # server_names = ['scaleway-fr', 'google', 'yandex', 'cloudflare']
 
 
-## List of local addresses and ports to listen to. Can be IPv4 and/or IPv6.
-## Note: When using systemd socket activation, choose an empty set (i.e. [] ).
-
-listen_addresses = ['127.0.0.1:53000', '[::1]:53000']
+listen_addresses = ['[::]:53000']
 
 
 ## Maximum number of simultaneous client connections to accept
@@ -171,21 +168,7 @@ cert_refresh_delay = 240
 # tls_cipher_suite = [52392, 49199]
 
 
-## Fallback resolver
-## This is a normal, non-encrypted DNS resolver, that will be only used
-## for one-shot queries when retrieving the initial resolvers list, and
-## only if the system DNS configuration doesn't work.
-## No user application queries will ever be leaked through this resolver,
-## and it will not be used after IP addresses of resolvers URLs have been found.
-## It will never be used if lists have already been cached, and if stamps
-## don't include host names without IP addresses.
-## It will not be used if the configured system DNS works.
-## A resolver supporting DNSSEC is recommended. This may become mandatory.
-##
-## People in China may need to use 114.114.114.114:53 here.
-## Other popular options include 8.8.8.8 and 1.1.1.1.
-
-fallback_resolver = '119.29.29.29:53'
+bootstrap_resolvers = ['208.67.222.222:5353', '8.8.4.4:53', '9.9.9.11:9953']
 
 
 ## Never let dnscrypt-proxy try to use the system DNS settings;


### PR DESCRIPTION
- [FATAL] listen tcp 127.0.0.1:53000: bind: Only one usage of each socket address (protocol/network address/port) is normally permitted.

- fallback_resolvers was renamed to bootstrap_resolvers for clarity. Please update your configuration file accordingly. [2.0.46-beta3](https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/2.0.46-beta3)