### PR TITLE
添加对于discord,duckduckgo,twitch和v2ex的支持

### DIFF
--- a/accesser/pac
+++ b/accesser/pac
@@ -58,7 +58,14 @@ var shexps = {
   "*://*.bbci.co.uk/*": 1,
   "*://*.japantimes.co.jp/*": 1,
   "*://*.yahoo.co.jp/*": 1,
-  "*://*.cna.com.tw/*": 1
+  "*://*.cna.com.tw/*": 1,
+  "*://*.discord.com/*": 1,
+  "*://*.discordapp.com/*": 1,
+  "*://*.discord.gg/*": 1,
+  "*://*.discordapp.net/*": 1,
+  "*://*.duckduckgo.com/*": 1,
+  "*://*.v2ex.com/*":1,
+  "*://*.twitch.tv/*":1
 };
 
 var proxy = "PROXY {{host}}:{{port}};";


### PR DESCRIPTION
看到 #123 ,正好周五试验过，效果不错，除了discordapp.net这个域名访问会报403 forbidden，其余的都没问题
ps：由于*.discordapp.net无法连接，所以无法从网页端下载应用(dl.discordapp.net)，但不加上会导致看不了图片(cdn.discordapp.com)