### PR TITLE
fix pixiv

### DIFF
--- a/accesser/config.toml
+++ b/accesser/config.toml
@@ -100,6 +100,8 @@ port = 53
 # 连接键所对应的域名时使用值所对应的IP。此设置优先于上面的DNS服务器设置。
 # When connecting the domain name corresponding to the key, use the IP corresponding to the value. This setting takes precedence over the DNS server setting above.
 
+"sketch.pixiv.net" = "210.140.174.37"
+"img-sketch.pixiv.net" = "210.140.131.145"
 ".pixiv.net" = "210.140.131.219"
 "www.bbc.co.uk" = "212.58.233.252"
 "www.wenxuecity.com" = "35.190.31.60"

--- a/accesser/config.toml
+++ b/accesser/config.toml
@@ -100,9 +100,9 @@ port = 53
 # 连接键所对应的域名时使用值所对应的IP。此设置优先于上面的DNS服务器设置。
 # When connecting the domain name corresponding to the key, use the IP corresponding to the value. This setting takes precedence over the DNS server setting above.
 
-"sketch.pixiv.net" = "210.140.174.37"
-"img-sketch.pixiv.net" = "210.140.131.145"
-".pixiv.net" = "210.140.131.219"
+
+"www.pixiv.net" = "210.140.131.219"
+"imp.pixiv.net" = "210.140.131.219"
 "www.bbc.co.uk" = "212.58.233.252"
 "www.wenxuecity.com" = "35.190.31.60"
 "m.wenxuecity.com" = "35.190.31.60"

--- a/accesser/pac
+++ b/accesser/pac
@@ -45,7 +45,8 @@ var domains = {
   "uptodown.com": 1,
   "vimeo.com": 1,
   "wenxuecity.com": 1,
-  "wikipedia.org": 1
+  "wikipedia.org": 1,
+  "pixivsketch.net": 1
 };
 
 var shexps = {


### PR DESCRIPTION
- 直接指定*.pixiv.net的hosts是有问题的，如[sketch.pixiv.net](sketch.pixiv.net)，只有[www.pixiv.net](https://www.pixiv.net),[imp.pixiv.net](https://imp.pixiv.net)需要，因为它们会解析到CloudflareIP
- *.pixivsketch.net是pixiv Sketch直播流媒体