### PR TITLE
add Mastodon and singlelogin

### DIFF
--- a/accesser/config.toml
+++ b/accesser/config.toml
@@ -112,6 +112,8 @@ nameserver = [
 "nyt.com" = "ecx.images-amazon.com"
 "*.nyt.com" = "ecx.images-amazon.com"
 "gn-web-assets.api.bbc.com" = "static-web-assets.gnl-common.bbcverticals.com"
+"mastodon.social" = "n.sni-347-default.ssl.fastly.net"
+"*.mastodon.social" = "n.sni-347-default.ssl.fastly.net"
 
 
 [hosts]
@@ -178,3 +180,5 @@ nameserver = [
 "scratch.mit.edu" = "151.101.2.133"
 "downloads.scratch.mit.edu" = "d2as4384mnnkdz.cloudfront.net"
 ".scratch.mit.edu" = "151.101.2.133"
+"singlelogin.re" = "195.66.210.33"
+".singlelogin.re" = "195.66.210.33"

--- a/accesser/pac
+++ b/accesser/pac
@@ -46,7 +46,9 @@ var domains = {
   "vimeo.com": 1,
   "wenxuecity.com": 1,
   "wikipedia.org": 1,
-  "scratch.mit.edu": 1
+  "scratch.mit.edu": 1,
+  "mastodon.social": 1,
+  "singlelogin.re": 1
 };
 
 var shexps = {


### PR DESCRIPTION
[singlelogin.re](https://singlelogin.re)原为 Z-Lib 刚复活时的登录页，后来变成图书馆域名，被墙。

如果不加hosts，会解析到不能用的176.123.7.105。