### PR TITLE
fix euronews.com and extensions-discovery-images.twitch.tv

### DIFF
--- a/accesser/config.toml
+++ b/accesser/config.toml
@@ -98,9 +98,11 @@ nameserver = [
 "vod-secure.twitch.tv" = "ds0h3roq6wcgc.cloudfront.net"
 "extension-files.twitch.tv" = "d36mepituis1gg.cloudfront.net"
 "panels.twitch.tv" = "d1ut6fykkt3imt.cloudfront.net"
+"extensions-discovery-images.twitch.tv" = "d3m1uefep57n8q.cloudfront.net"
 "downloads.scratch.mit.edu" = "d2as4384mnnkdz.cloudfront.net"
 "gn-web-assets.api.bbc.com" = "static-web-assets.gnl-common.bbcverticals.com"
 "onedrive.live.com" = "0.azureedge.net"
+"euronews.com" = "euronews.news"
 
 
 [cert_verify]
@@ -116,7 +118,6 @@ nameserver = [
 "*.singlelogin.re" = ["1lib.fr", "singlelogin.se", "singlelogin.re"]
 "scratch.mit.edu" = ["scratchfoundation.map.fastly.net"]
 "*.scratch.mit.edu" = ["scratchfoundation.map.fastly.net"]
-"euronews.com" = ["fastly.com"]
 "*.euronews.com" = ["fastly.com"]
 "mega.io" = ["static.mega.co.nz"]
 "bandcamp.com" = ["fastly.com"]
@@ -178,6 +179,7 @@ nameserver = [
 ".redditstatic.com" = "fastly.com"
 "redditmedia.com" = "fastly.com"
 ".redditmedia.com" = "fastly.com"
+".euronews.com" = "fastly.com"
 "www.bbc.com" = "151.101.128.81"
 "disqus.com" = "151.101.64.134"
 "i.imgur.com" = "151.101.196.193"


### PR DESCRIPTION
- #163 [euronews.com](https://euronews.com) CDN 为亚马逊云，其二级域名的 CDN 才是 Fastly。
- [extensions-discovery-images.twitch.tv](https://extensions-discovery-images.twitch.tv)[需指定server_name字段](https://github.com/URenko/Accesser/pull/163#issuecomment-2092002621)。

另外，[www.nicovideo.jp](https://www.nicovideo.jp)、[dcdn.cdn.nicovideo.jp](https://dcdn.cdn.nicovideo.jp)和[Twitch资源加载](https://assets.twicth.tv)都没有[可用cname作为SNI](https://github.com/URenko/Accesser/pull/91)，应该无法支持了。