### PR TITLE
fix euronews.com

### DIFF
--- a/accesser/config.toml
+++ b/accesser/config.toml
@@ -102,7 +102,6 @@ nameserver = [
 "downloads.scratch.mit.edu" = "d2as4384mnnkdz.cloudfront.net"
 "gn-web-assets.api.bbc.com" = "static-web-assets.gnl-common.bbcverticals.com"
 "onedrive.live.com" = "0.azureedge.net"
-"euronews.com" = "euronews.news"
 
 
 [cert_verify]


### PR DESCRIPTION
[euronews.com](https://euronews.com)仅置空 SNI 即可。