### PR TITLE
fix singlelogin.re, remove singlelogin.se and add hub.docker.com

### DIFF
--- a/accesser/config.toml
+++ b/accesser/config.toml
@@ -79,7 +79,6 @@ nameserver = [
 
 "www.quora.com" = "fs.quoracdn.net"
 "sketch.pixiv.net" = "pixivsketch.net"
-"cdn1-smallimg.phncdn.com" = "pabbp.com"
 "nyaa.si" = "ddos-guard.net"
 "site.nicovideo.jp" = "d4fsvsnk8os9s.cloudfront.net"
 "blog.nicovideo.jp" = "d11c2xcc0ucqv1.cloudfront.net"
@@ -215,5 +214,5 @@ nameserver = [
 "archive.org" = "207.241.224.27"
 "mastodon.social" = "fastly.com"
 "*.mastodon.social" = "fastly.com"
-"singlelogin.se" = "195.66.210.33"
-".singlelogin.se" = "195.66.210.33"
+"singlelogin.re" = "176.123.7.105"
+".singlelogin.re" = "176.123.7.105"

--- a/accesser/pac
+++ b/accesser/pac
@@ -51,7 +51,6 @@ var domains = {
   "wikisource.org": 1,
   "wikidata.org": 1,
   "singlelogin.re": 1,
-  "singlelogin.se": 1,
   "archive.org": 1,
   "amazon.co.jp": 1,
   "discord.com": 1,

--- a/accesser/pac
+++ b/accesser/pac
@@ -61,7 +61,8 @@ var domains = {
   "twitch.tv": 1,
   "scratch.mit.edu": 1,
   "bandcamp.com": 1,
-  "mastodon.social": 1
+  "mastodon.social": 1,
+  "hub.docker.com": 1
 };
 
 var shexps = {


### PR DESCRIPTION
`"cdn1-smallimg.phncdn.com" = "pabbp.com"`无效；
[singlelogin.re](https://singlelogin.re) 有时无法解析，且现仅`176.123.7.105`一个 IP；
[singlelogin.se](https://singlelogin.se) 被扣押。