### PR TITLE
fix Wikimedia maps

### DIFF
--- a/accesser/config.toml
+++ b/accesser/config.toml
@@ -207,6 +207,7 @@ nameserver = [
 ".wikidata.org" = "text-lb.esams.wikimedia.org"
 "wikimedia.org" = "text-lb.esams.wikimedia.org"
 "upload.wikimedia.org" = "upload-lb.esams.wikimedia.org"
+"maps.wikimedia.org" = "upload-lb.esams.wikimedia.org"
 ".wikimedia.org" = "text-lb.esams.wikimedia.org"
 "exhentai.org" = "178.175.128.252"
 "scratch.mit.edu" = "scratchfoundation.map.fastly.net"


### PR DESCRIPTION
[maps.wikimedia.org](https://maps.wikimedia.org) 与 [upload.wikimedia.org](https://upload.wikimedia.org) 为同一数据中心