### PR TITLE
fix Twitch(#181), Niconico and cn.nytimes.com

### DIFF
--- a/accesser/config.toml
+++ b/accesser/config.toml
@@ -70,6 +70,8 @@ nameserver = [
 "www.google.com/recaptcha/" = "www.recaptcha.net/recaptcha/"
 "tumblr.com/" = "www.tumblr.com/"
 "instagram.com/" = "www.instagram.com/"
+"nicovideo.jp/" = "www.nicovideo.jp/"
+"twitch.tv/" = "www.twitch.tv/"
 
 
 [alter_hostname]
@@ -80,25 +82,10 @@ nameserver = [
 "www.quora.com" = "fs.quoracdn.net"
 "sketch.pixiv.net" = "pixivsketch.net"
 "nyaa.si" = "ddos-guard.net"
-"site.nicovideo.jp" = "d4fsvsnk8os9s.cloudfront.net"
-"blog.nicovideo.jp" = "d11c2xcc0ucqv1.cloudfront.net"
-"info.nicovideo.jp" = "d2c1o7y4lmdvf6.cloudfront.net"
-"site.live.stage.nicovideo.jp" = "d1kbkmcy8xlds0.cloudfront.net"
-"anime.nicovideo.jp" = "d1m4g6tauw16ys.cloudfront.net"
-"site.live.nicovideo.jp" = "d15yc1ruklb1w6.cloudfront.net"
-"dcdn.cdn.nicovideo.jp" = "d2urq2sf7li1b4.cloudfront.net"
-"static.prod.blogaws.nicovideo.jp" = "d11c2xcc0ucqv1.cloudfront.net"
-"pipelines.actions.githubusercontent.com" = "origin.mediaservices.windows.net"
 "steamcommunity.com" = "www.valvesoftware.com"
-"docs.github.com" = "api.github.com"
 "pubsub-edge.twitch.tv" = "external-2.us-west-2.prod.twitchpubsubedge.twitch.a2z.com"
 "irc-ws.chat.twitch.tv" = "websocket-7.us-west-2.prod.twitchircedge.twitch.a2z.com"
-"vod-secure.twitch.tv" = "ds0h3roq6wcgc.cloudfront.net"
-"extension-files.twitch.tv" = "d36mepituis1gg.cloudfront.net"
-"panels.twitch.tv" = "d1ut6fykkt3imt.cloudfront.net"
-"extensions-discovery-images.twitch.tv" = "d3m1uefep57n8q.cloudfront.net"
 "gn-web-assets.api.bbc.com" = "static-web-assets.gnl-common.bbcverticals.com"
-"onedrive.live.com" = "0.azureedge.net"
 
 
 [cert_verify]
@@ -119,6 +106,7 @@ nameserver = [
 "bandcamp.com" = ["fastly.com"]
 "*.bandcamp.com" = ["fastly.com"]
 "nytimes.com" = ["fastly.com"]
+"cn.nytimes.com" = ["cloudfront.com"]
 "*.nytimes.com" = ["fastly.com"]
 "reddit.com" = ["fastly.com"]
 "*.reddit.com" = ["fastly.com"]
@@ -131,6 +119,7 @@ nameserver = [
 "*.redditinc.com" = ["fastly.com"]
 "mastodon.social" = ["fastly.com"]
 "*.mastodon.social" = ["fastly.com"]
+"gql.twitch.tv" = ["fastly.com"]
 
 
 [hosts]
@@ -152,15 +141,11 @@ nameserver = [
 "adserver.wenxuecity.com" = "0.0.0.0"
 "www.dropbox.com" = "162.125.69.1"
 ".appledaily.com" = "60.254.170.127"
+"e-hentai.org" = "e-hentai.org.cdn.cloudflare.net"
 ".e-hentai.org" = "e-hentai.org.cdn.cloudflare.net"
-"info.nicovideo.jp" = "d2c1o7y4lmdvf6.cloudfront.net"
-"blog.nicovideo.jp" = "d11c2xcc0ucqv1.cloudfront.net"
-"site.nicovideo.jp" = "d4fsvsnk8os9s.cloudfront.net"
-"site.live.stage.nicovideo.jp" = "d1kbkmcy8xlds0.cloudfront.net"
-"anime.nicovideo.jp" = "d1m4g6tauw16ys.cloudfront.net"
-"site.live.nicovideo.jp" = "d15yc1ruklb1w6.cloudfront.net"
-"dcdn.cdn.nicovideo.jp" = "d2urq2sf7li1b4.cloudfront.net"
-"static.prod.blogaws.nicovideo.jp" = "d11c2xcc0ucqv1.cloudfront.net"
+"nicovideo.jp" = "13.33.171.121"
+"qa.nicovideo.jp" = "124.146.170.109"
+".nicovideo.jp" = "13.33.171.121"
 "bandcamp.com" = "fastly.com"
 ".bandcamp.com" = "fastly.com"
 "nytimes.com" = "fastly.com"
@@ -217,3 +202,11 @@ nameserver = [
 ".singlelogin.re" = "176.123.7.105"
 "1lib.sk" = "176.123.7.105"
 ".1lib.sk" = "176.123.7.105"
+"gql.twitch.tv" = "fastly.com"
+"assets.twitch.tv" = "13.33.171.121"
+"vod-secure.twitch.tv" = "13.33.171.121"
+"extension-files.twitch.tv" = "13.33.171.121"
+"panels.twitch.tv" = "13.33.171.121"
+"clips-media-assets2.twitch.tv" = "13.33.171.121"
+"extensions-discovery-images.twitch.tv" = "13.33.171.121"
+"passport.twitch.tv" = "13.33.171.121"

--- a/accesser/pac
+++ b/accesser/pac
@@ -72,7 +72,6 @@ var shexps = {
   "*://search.yahoo.co.jp/*": 1,
   "*://*.cna.com.tw/*": 1,
   "*://media.discordapp.net/*": 1,
-  "*://*.dmc.nico/*": 1,
   "*://i.pximg.net/*": 1,
   "*://*.pixivsketch.net/*": 1,
   "*://*.githubassets.com/*": 1,


### PR DESCRIPTION
对于用了 CloudFront CDN 的网站，一般没有 CNAME 就不支持域前置，但其 hosts 指定为`13.33.171.121`就可以不发送 SNI 访问（websocket 协议的不行，如wss://irc-ws.chat.twitch.tv）。

Twitch 还剩多少域名未加不知道；[qa.nicovideo.jp](https://qa.nicovideo.jp)不是 CloudFront CDN，一直超时；Niconico 复活后视频资源域名不是*.dmc.nico了，估计已弃用，故移除。

[pipelines.actions.githubusercontent.com](https://pipelines.actions.githubusercontent.com)、[docs.github.com](https://docs.github.com)、[onedrive.live.com](https://onedrive.live.com)现不发送 SNI 也行。