### PR TITLE
Added id.twitch.tv to fix the jump on initial login

### DIFF
--- a/accesser/config.toml
+++ b/accesser/config.toml
@@ -119,6 +119,7 @@ nameserver = [
 "*.mastodon.social" = ["fastly.com"]
 "www.twitch.tv" = ["twitch.tv"]
 "m.twitch.tv" = ["twitch.tv"]
+"id.twitch.tv" = ["twitch.tv"]
 "gql.twitch.tv" = ["fastly.com"]
 "pubsub-edge.twitch.tv" = ["external-2.us-west-2.prod.twitchpubsubedge.twitch.a2z.com"]
 "irc-ws.chat.twitch.tv" = ["websocket-7.us-west-2.prod.twitchircedge.twitch.a2z.com"]


### PR DESCRIPTION
我试着在 m.twitch.tv 登陆，好不容易登上去了结果还要跳到这个域名
这个域名也被 SNI 阻断，加上后即可正常跳转