### PR TITLE
fix greasyfork.org

### DIFF
--- a/accesser/rules.toml
+++ b/accesser/rules.toml
@@ -183,3 +183,4 @@ nameserver = [
 # ".singlelogin.re" = "176.123.7.228"
 # "singlelogin.re" = "176.123.7.252"
 # ".singlelogin.re" = "176.123.7.252"
+"greasyfork.org" = "update.greasyfork.org"


### PR DESCRIPTION
`greasyfork.org` 会返回 cloudflare 的 ip。将其映射到了 `update.greasyfork.org`。