### PR TITLE
load rules configuration file from rules directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ hosts
 .1
 config.toml
 rules.toml
+rules
+
+# vscode
+.vscode

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ accesser
 *可以使用例如[pyenv](https://github.com/pyenv/pyenv)来安装所需的Python版本（推荐Python 3.11+）。
 
 ## 设置
-启动一次Accesser后，会在 **工作目录** 下生成`config.toml` 和 `rules.toml`，具体含义见其中注释，保存后重新打开程序。
+启动一次Accesser后，会在 **工作目录** 下生成`config.toml`，具体含义见其中注释，保存后重新打开程序。同时也会生成目录 `rules`，用于存放规则文件。规则的配置方式请参见 [`custom.toml.sample`](accesser/custom.toml.sample)
 
 ## 进阶1: 与v2ray等其他代理软件一起使用
 Accesser是一个本地HTTP代理，默认代理地址为`http://localhost:7654`，只要网络流量能从其他代理软件以HTTP代理导出就能联合使用。

--- a/accesser/__init__.py
+++ b/accesser/__init__.py
@@ -203,15 +203,8 @@ async def main():
     global context, cert_store, cert_lock, DNSresolver
     print(f"Accesser v{__version__}  Copyright (C) 2018-2024  URenko")
     setting.parse_args()
-
-    if setting.rules_update_case in ('old', 'missing'):
-        logger.warning("Updated rules.toml because it is %s.", setting.rules_update_case)
-    elif setting.rules_update_case == 'modified':
-        logger.warning("You've already modified rules.toml, so it won't be updated automatically!")
-    else:
-        logger.debug("rules.toml status: %s", setting.rules_update_case)
     
-    if any(_keys in setting._config for _keys in setting._rules):
+    if any(_keys in setting._config for _keys in setting._config):
         logger.warning("Some sections of config.toml overlap with rules.toml, config.toml has higher priority, but this may make rule updates ineffective.")
         
     DNSresolver = dns.asyncresolver.Resolver(configure=False)

--- a/accesser/__init__.py
+++ b/accesser/__init__.py
@@ -211,7 +211,7 @@ async def main():
     else:
         logger.debug("rules.toml status: %s", setting.rules_update_case)
 
-    if any(_keys in setting._config for _keys in setting._config):
+    if any(_keys in setting._config for _keys in setting._rules):
         logger.warning("Some sections of config.toml overlap with rules.toml, config.toml has higher priority, but this may make rule updates ineffective.")
         
     DNSresolver = dns.asyncresolver.Resolver(configure=False)

--- a/accesser/__init__.py
+++ b/accesser/__init__.py
@@ -204,6 +204,13 @@ async def main():
     print(f"Accesser v{__version__}  Copyright (C) 2018-2024  URenko")
     setting.parse_args()
     
+    if setting.rules_update_case in ('old', 'missing'):
+        logger.warning("Updated rules.toml because it is %s.", setting.rules_update_case)
+    elif setting.rules_update_case == 'modified':
+        logger.warning("You've already modified rules.toml, so it won't be updated automatically!")
+    else:
+        logger.debug("rules.toml status: %s", setting.rules_update_case)
+
     if any(_keys in setting._config for _keys in setting._config):
         logger.warning("Some sections of config.toml overlap with rules.toml, config.toml has higher priority, but this may make rule updates ineffective.")
         

--- a/accesser/custom.toml.sample
+++ b/accesser/custom.toml.sample
@@ -1,0 +1,48 @@
+# 这是Accesser的规则（除路由规则）文件。
+# This is the rule (except routing rules) file of Accesser.
+# 将 toml 格式的规则文件放置在工作目录下的 rules 目录可向 Accesser 添加规则。规则优先级为 `config.toml` > `rules/*.toml` > 安装目录下的 `rules.toml`
+# You can add rules to the Accesser by placing a toml-formatted rules file in the rules directory under the working directory. Rules with priority of 'config.toml' > 'rules/*.toml' > 'rules.toml' in the installation directory
+
+[DNS]
+
+# DNS服务器地址。可于下方 hosts 字段指定DNS服务器 host 对应的 IP 地址。
+# DNS server address. You can specify bootstrap IP address in the [hosts] field below.
+nameserver = [
+  #"https://77.88.8.8/dns-query",          # https://host|IP[:port]/path # DNS-over-HTTPS (DoH)
+  #"tls://149.112.112.112",            # tls://host|IP[:port]  # DNS-overTLS (DoT)
+  # "quic://dns.adguard-dns.com",     # quic://host|IP[:port] # DNS-over-QUIC (DoQ)
+  # "localhost"                       # host|IP[:port]        # 传统 UDP DNS | traditional UDP DNS
+]
+
+
+[http_redirect]
+
+# 如果一个HTTP（无TLS）请求的URL以下面某个键开头，则会被重定向到其值对应的URL（通过HTTPS请求）。
+# If the URL of an HTTP (no TLS) request starts with one of the following keys, it will be redirected to the URL corresponding to its value (via HTTPS request).
+
+# "example.com/" = "www.example.com/"
+
+[alter_hostname]
+
+# 与键对应的域名的TLS连接会使用其值对应的域名作为server_name字段，并且校验证书时也使用这一域名。键支持Unix shell风格的通配符。
+# A TLS connection to the domain corresponding to the key will use the domain name corresponding to its value as the server_name field, and this domain name is also used when verifying the certificate. The key supports Unix shell-style wildcards.
+
+# "example.com" = "notblocked.com"
+
+[cert_verify]
+
+# 为域名分别设置证书校验策略，其值可以是一个包含用于校验的域名的列表（有一个匹配就通过），也可以是 false 表示不校验
+# 这比 [alter_hostname] 和全局的 check_hostname 的优先级高，但不会在 Client Hello 中作为 server_name 发送。
+# Set the certificate validation policy for domains individually. The values can be a array contain strings which represent the domain name used to verify the certificate (pass if there is a match), or false which means disabling the verification.
+# It has as a higher priority than [alter_hostname] and the global check_hostname, but will not be sent as server_name in Client Hello.
+
+# "example.com" = ["example.org", "example.net", "example.xyz"]
+
+[hosts]
+
+# 自定义 域名-IP 映射，即用于与网站建立连接，也用于与DNS服务器建立连接。
+# Customize domain-IP mapping, which is used to establish a connection with the website and the DNS server.
+
+# example for DNS server bootstrap address
+# "dot.sb" = "185.222.222.222"
+# "dns.adguard-dns.com" = "94.140.14.14"

--- a/accesser/rules.toml
+++ b/accesser/rules.toml
@@ -1,7 +1,9 @@
-# 这是Accesser的规则（除路由规则）文件，保存到程序 ⚠工作目录⚠ 后重启程序生效。
-# This is the rule (except routing rules) file of Accesser, save it to the program ⚠ working directory ⚠ and restart the program to take effect.
-# 在未曾被修改过的情况下，它会自动随Accesser更新。
-# If it has not been modified, it will be automatically updated with Accesser.
+# 请不要直接修改此文件。你可以通过将配置文件复制到工作目录下的 rules 文件夹中以达到向 Accesser 添加规则的目的。
+# Please do not edit the file directly. You can copy the rules configuration file to the rules directory under working directory to add rules to Accesser.
+# 这是Accesser的规则（除路由规则）文件。
+# This is the rule (except routing rules) file of Accesser.
+# 它会自动随Accesser更新。
+# it will be automatically updated with Accesser.
 
 [DNS]
 

--- a/accesser/rules.toml
+++ b/accesser/rules.toml
@@ -2,8 +2,8 @@
 # Please do not edit the file directly. You can copy the rules configuration file to the rules directory under working directory to add rules to Accesser.
 # 这是Accesser的规则（除路由规则）文件。
 # This is the rule (except routing rules) file of Accesser.
-# 它会自动随Accesser更新。
-# it will be automatically updated with Accesser.
+# 在未曾被修改过的情况下，它会自动随Accesser更新。
+# If it has not been modified, it will be automatically updated with Accesser.
 
 [DNS]
 

--- a/accesser/utils/setting.py
+++ b/accesser/utils/setting.py
@@ -37,25 +37,26 @@ if rules_update_case in ("old", "missing"):
     shutil.copyfile(basepath / "rules.toml", "rules.toml")
     os.utime("rules.toml", ns=(0, 0))
 
-_config = {}
+_rules = {}
 
 if not Path("rules").exists() or not Path("rules").is_dir():
     Path("rules").mkdir()
 
-for custom_config in Path("rules").glob("*.toml"):
-    with custom_config.open(mode="rb") as f:
-        _config = deep_merge(_config, tomllib.load(f))
+for custom_rules in Path("rules").glob("*.toml"):
+    with custom_rules.open(mode="rb") as f:
+        _rules = deep_merge(_rules, tomllib.load(f))
 
 with Path("rules.toml").open(mode="rb") as f:
-    _config = deep_merge(_config, tomllib.load(f))
+    _rules = deep_merge(_rules, tomllib.load(f))
 
 if not Path("config.toml").exists():
     shutil.copyfile(basepath / "config.toml", "config.toml")
 
 with open("config.toml", "rb") as f:
-    config = tomllib.load(f)
+    _config = tomllib.load(f)
 
-config = deep_merge(config, _config)
+config = _rules.copy()
+config = deep_merge(_config, _rules)
 
 
 def parse_args():

--- a/accesser/utils/setting.py
+++ b/accesser/utils/setting.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-import shutil, os, filecmp
+import shutil
+
 try:
     import tomllib
 except ModuleNotFoundError:
@@ -8,36 +9,55 @@ import argparse
 
 basepath = Path(__file__).parent.parent
 
-if Path('rules.toml').exists():
-    if Path('rules.toml').stat().st_mtime_ns > 0:
-        rules_update_case = 'modified'
-    else:
-        if filecmp.cmp('rules.toml', basepath / 'rules.toml'):
-            rules_update_case = 'holding'
-        else:
-            rules_update_case = 'old'
-else:
-    rules_update_case = 'missing'
-if rules_update_case in ('old', 'missing'):
-    shutil.copyfile(basepath / 'rules.toml', 'rules.toml')
-    os.utime('rules.toml', ns=(0, 0))
-with open('rules.toml', 'rb') as f:
-    _rules = tomllib.load(f)
-    config = _rules.copy()
 
-if not Path('config.toml').exists():
-    shutil.copyfile(basepath / 'config.toml', 'config.toml')
-with open('config.toml', 'rb') as f:
-    _config = tomllib.load(f)
+def deep_merge(config_a: dict, config_b: dict):
+    res = config_b | config_a
+    for key in config_a:
+        if key in config_b and type(config_a[key]) is type(config_b[key]):
+            if isinstance(config_a[key], dict):
+                res[key] = deep_merge(config_a[key], config_b[key])
+            elif isinstance(config_a[key], list):
+                for elem in config_b[key]:
+                    if elem not in res[key]:
+                        res[key].append(elem)
+    return res
 
-config |= _config
+
+_config = {}
+
+if not Path("rules").exists() or not Path("rules").is_dir():
+    Path("rules").mkdir()
+
+for custom_config in Path("rules").glob("*.toml"):
+    with custom_config.open(mode="rb") as f:
+        _config = deep_merge(_config, tomllib.load(f))
+
+with basepath.joinpath("rules.toml").open(mode="rb") as f:
+    _config = deep_merge(_config, tomllib.load(f))
+
+if not Path("config.toml").exists():
+    shutil.copyfile(basepath / "config.toml", "config.toml")
+
+with open("config.toml", "rb") as f:
+    config = tomllib.load(f)
+
+config = deep_merge(config, _config)
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--notsetproxy', action='store_true', help='do not set system\'s pac proxy automatically')
-    parser.add_argument('--notimportca', action='store_true', help='do not import certificate to system automatically')
+    parser.add_argument(
+        "--notsetproxy",
+        action="store_true",
+        help="do not set system's pac proxy automatically",
+    )
+    parser.add_argument(
+        "--notimportca",
+        action="store_true",
+        help="do not import certificate to system automatically",
+    )
     args = parser.parse_args()
     if args.notsetproxy:
-        config['setproxy'] = False
+        config["setproxy"] = False
     if args.notimportca:
-        config['importca'] = False
+        config["importca"] = False

--- a/accesser/utils/setting.py
+++ b/accesser/utils/setting.py
@@ -42,7 +42,7 @@ _rules = {}
 if not Path("rules").exists() or not Path("rules").is_dir():
     Path("rules").mkdir()
 
-for custom_rules in Path("rules").glob("*.toml"):
+for custom_rules in sorted(Path("rules").glob("*.toml"), key=lambda f: f.name):
     with custom_rules.open(mode="rb") as f:
         _rules = deep_merge(_rules, tomllib.load(f))
 


### PR DESCRIPTION
#230 
更改：
- 不会再将 `rules.toml` 复制到工作目录
- 将从工作目录下的 `rules` 中加载额外配置，目录不存在会自动创建。优先级高于默认的 `rules.toml`，但仍低于 `config.toml`。
- `deep_merge` 函数用于合并配置。该函数将递归合并字典共有的，值的类型相等且都为 `list` 或者 `dict` 的值。如果有冲突，以传入的 `config_a` 为准。