### PR TITLE
fix #248

### DIFF
--- a/accesser/__init__.py
+++ b/accesser/__init__.py
@@ -51,7 +51,7 @@ async def update_cert(server_name):
     async with cert_lock:
         if not server_name in cert_store:
             cm.create_certificate(server_name)
-        context.load_cert_chain(os.path.join(cm.certpath, "{}.crt".format(server_name)))
+        context.load_cert_chain(setting.certpath.joinpath("{}.crt".format(server_name)))
         cert_store.add(server_name)
 
 async def send_pac(writer: asyncio.StreamWriter):
@@ -64,7 +64,7 @@ async def send_pac(writer: asyncio.StreamWriter):
     await writer.wait_closed()
 
 async def send_crt(writer: asyncio.StreamWriter, path: str):
-    with open(os.path.join(cm.certpath, path.rsplit(sep = '/',maxsplit = 1)[-1]), 'rb') as f:
+    with open(setting.certpath, (path.rsplit(sep = '/',maxsplit = 1)[-1]), 'rb') as f:
         crt = f.read()
     writer.write(f'HTTP/1.1 200 OK\r\nContent-Type: application/x-x509-ca-cert\r\nContent-Length: {len(crt)}\r\n\r\n'.encode('iso-8859-1'))
     writer.write(crt)

--- a/accesser/__init__.py
+++ b/accesser/__init__.py
@@ -209,7 +209,10 @@ async def main():
     global context, cert_store, cert_lock, DNSresolver
     print(f"Accesser v{__version__}  Copyright (C) 2018-2024  URenko")
     setting.parse_args()
-    
+    if os.geteuid() == 0:
+        logger.warning(
+            "Running Accesser as the root user carries certain risks. Do not use it in production."
+        )
     if setting.rules_update_case in ('old', 'missing'):
         logger.warning("Updated rules.toml because it is %s.", setting.rules_update_case)
     elif setting.rules_update_case == 'modified':

--- a/accesser/__init__.py
+++ b/accesser/__init__.py
@@ -30,6 +30,7 @@ from urllib.parse import urlsplit
 from packaging.version import Version
 from tld import get_tld, is_tld
 import dns, dns.asyncresolver, dns.nameserver
+import platform
 
 from .utils import certmanager as cm
 from .utils import importca
@@ -209,10 +210,11 @@ async def main():
     global context, cert_store, cert_lock, DNSresolver
     print(f"Accesser v{__version__}  Copyright (C) 2018-2024  URenko")
     setting.parse_args()
-    if os.geteuid() == 0:
-        logger.warning(
-            "Running Accesser as the root user carries certain risks. Do not use it in production."
-        )
+    if platform.system() == "Linux" or platform.system() == "FreeBSD":
+        if os.geteuid() == 0:
+            logger.warning(
+                "Running Accesser as the root user carries certain risks. Do not use it in production."
+            )
     if setting.rules_update_case in ('old', 'missing'):
         logger.warning("Updated rules.toml because it is %s.", setting.rules_update_case)
     elif setting.rules_update_case == 'modified':

--- a/accesser/utils/certmanager.py
+++ b/accesser/utils/certmanager.py
@@ -34,9 +34,10 @@ from cryptography.x509.extensions import (
 from cryptography.x509.oid import ExtendedKeyUsageOID
 
 from .log import logger
+
 logger = logger.getChild("certmanager")
 from . import setting
-from .setting import certpath
+
 
 def create_root_ca():
     key = rsa.generate_private_key(
@@ -86,11 +87,11 @@ def create_root_ca():
         .sign(key, hashes.SHA256())
     )
 
-    (certpath / "root.crt").write_bytes(
+    setting.certpath.joinpath("root.crt").write_bytes(
         cert.public_bytes(serialization.Encoding.PEM)
     )
 
-    (certpath / "root.key").write_bytes(
+    setting.certpath.joinpath("root.key").write_bytes(
         key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.PKCS8,
@@ -98,7 +99,7 @@ def create_root_ca():
         )
     )
 
-    (certpath / "root.pfx").write_bytes(
+    setting.certpath.joinpath("root.pfx").write_bytes(
         serialization.pkcs12.serialize_key_and_certificates(
             b"Accesser", key, cert, None, serialization.NoEncryption()
         )
@@ -106,8 +107,8 @@ def create_root_ca():
 
 
 def create_certificate(server_name):
-    rootpem = (certpath / "root.crt").read_bytes()
-    rootkey = (certpath / "root.key").read_bytes()
+    rootpem = (setting.certpath / "root.crt").read_bytes()
+    rootkey = (setting.certpath / "root.key").read_bytes()
     ca_cert = x509.load_pem_x509_certificate(rootpem)
     pkey = serialization.load_pem_private_key(rootkey, password=None)
 
@@ -174,7 +175,7 @@ def create_certificate(server_name):
         .sign(pkey, hashes.SHA256())
     )
 
-    (certpath / f"{server_name}.crt").write_bytes(
+    (setting.certpath / f"{server_name}.crt").write_bytes(
         cert.public_bytes(serialization.Encoding.PEM)
         + pkey.private_bytes(
             encoding=serialization.Encoding.PEM,

--- a/accesser/utils/certmanager.py
+++ b/accesser/utils/certmanager.py
@@ -36,52 +36,7 @@ from cryptography.x509.oid import ExtendedKeyUsageOID
 from .log import logger
 logger = logger.getChild("certmanager")
 from . import setting
-from .setting import basepath
-
-
-def decide_state_path_legacy():
-    if setting.config["importca"]:
-        return Path(basepath)
-    else:
-        return Path()
-
-
-def decide_state_path_unix_like():
-    if os.geteuid() == 0:
-        logger.warn("Running Accesser as the root user carries certain risks; see pull #245")
-        return Path("/var/lib") / "accesser"
-
-    state_path = os.getenv("XDG_STATE_HOME", None)
-    if state_path is not None:
-        state_path = Path(state_path) / "accesser"
-    else:
-        state_path = Path.home() / ".local/state" / "accesser"
-    return state_path
-
-
-def decide_certpath():
-    certpath = None
-    # 人为指定最优先
-    #if setting.config["state_dir"]:
-        #return Path(setting.config["state_dir"]) / "cert"
-    match platform.system():
-        case 'Linux' | 'FreeBSD':
-            deprecated_path = decide_state_path_legacy() / "CERT"
-            # 暂仅在 *nix 上视为已废弃
-            if deprecated_path.exists():
-                logger.warn("deprecated path, see pull #245")
-                return deprecated_path
-            certpath = decide_state_path_unix_like() / "cert"
-        case _:
-            # windows,mac,android ...
-            certpath = decide_state_path_legacy() / "CERT"
-    return certpath
-
-
-certpath = decide_certpath()
-if not certpath.exists():
-    os.makedirs(certpath, exist_ok=True)
-
+from .setting import certpath
 
 def create_root_ca():
     key = rsa.generate_private_key(

--- a/accesser/utils/certmanager.py
+++ b/accesser/utils/certmanager.py
@@ -16,9 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os, platform
 import datetime
-from pathlib import Path
 
 from cryptography import x509
 from cryptography.x509.oid import NameOID

--- a/accesser/utils/certmanager.py
+++ b/accesser/utils/certmanager.py
@@ -107,8 +107,8 @@ def create_root_ca():
 
 
 def create_certificate(server_name):
-    rootpem = (setting.certpath / "root.crt").read_bytes()
-    rootkey = (setting.certpath / "root.key").read_bytes()
+    rootpem = setting.certpath.joinpath("root.crt").read_bytes()
+    rootkey = setting.certpath.joinpath("root.key").read_bytes()
     ca_cert = x509.load_pem_x509_certificate(rootpem)
     pkey = serialization.load_pem_private_key(rootkey, password=None)
 
@@ -175,7 +175,7 @@ def create_certificate(server_name):
         .sign(pkey, hashes.SHA256())
     )
 
-    (setting.certpath / f"{server_name}.crt").write_bytes(
+    setting.certpath.joinpath(f"{server_name}.crt").write_bytes(
         cert.public_bytes(serialization.Encoding.PEM)
         + pkey.private_bytes(
             encoding=serialization.Encoding.PEM,

--- a/accesser/utils/importca.py
+++ b/accesser/utils/importca.py
@@ -57,16 +57,15 @@ def import_windows_ca():
             # sys.exit(5)
             logger.warning('Try to manually import the certificate')
     else:
-        with setting.certpath.joinpath("root.pfx").open("wb") as pfxfile:
-            private_key, certificate, _ = pkcs12.load_key_and_certificates(pfxfile.read(), password=None)
-        with setting.certpath.joinpath("root.crt").open("wb") as certfile:
-            certfile.write(certificate.public_bytes(serialization.Encoding.PEM))
-        with setting.certpath.joinpath("root.key").open("wb") as pkeyfile:
-            pkeyfile.write(private_key.private_bytes(
+        private_key, certificate, _ = pkcs12.load_key_and_certificates(setting.certpath.joinpath("root.pfx").read_bytes(), password=None)
+        setting.certpath.joinpath("root.crt").write_bytes(certificate.public_bytes(serialization.Encoding.PEM))
+        setting.certpath.joinpath("root.key").write_bytes(
+            private_key.private_bytes(
                 encoding=serialization.Encoding.PEM,
                 format=serialization.PrivateFormat.PKCS8,
                 encryption_algorithm=serialization.NoEncryption(),
-            ))
+            )
+        )
 
 def import_mac_ca():
     ca_hash = CertUtil.ca_thumbprint.replace(':', '')

--- a/accesser/utils/importca.py
+++ b/accesser/utils/importca.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys
-from pathlib import Path 
 import subprocess
 import locale
 
@@ -27,9 +26,9 @@ from cryptography.hazmat.primitives.serialization import pkcs12
 from . import setting
 from . import certmanager as cm
 from .log import logger
+from .setting import certpath
 logger = logger.getChild('importca')
 
-certpath = cm.certpath
 
 def logandrun(cmd):
     if hasattr(subprocess, 'STARTUPINFO'):

--- a/accesser/utils/setting.py
+++ b/accesser/utils/setting.py
@@ -70,9 +70,6 @@ def decide_state_path_legacy():
 
 def decide_state_path_unix_like():
     if os.geteuid() == 0:
-        logging.warning(
-            "Running Accesser as the root user carries certain risks. Do not use it in production."
-        )
         return Path("/var/lib") / "accesser"
 
     state_path = os.getenv("XDG_STATE_HOME", None)

--- a/accesser/utils/setting.py
+++ b/accesser/utils/setting.py
@@ -85,7 +85,7 @@ def decide_state_path_unix_like():
 
 def decide_certpath():
     # 人为指定最优先
-    if config["state_dir"]:
+    if "state_dir" in config and config["state_dir"] is not None:
         return Path(config["state_dir"]) / "CERT"
     match platform.system():
         case "Linux" | "FreeBSD":
@@ -128,4 +128,6 @@ def parse_args():
     if args.state_dir is not None:
         config["state_dir"] = args.state_dir
     certpath = decide_certpath()
+    if not certpath.exists() or certpath.is_file():
+        certpath.mkdir(parents=True)
     return

--- a/accesser/utils/setting.py
+++ b/accesser/utils/setting.py
@@ -87,9 +87,9 @@ def decide_certpath():
     match platform.system():
         case "Linux" | "FreeBSD":
             deprecated_path = decide_state_path_legacy() / "CERT"
-            # 暂仅在 *nix 上视为已废弃
             if deprecated_path.exists():
-                logging.warning("deprecated path, see pull #245")
+                logging.warning("cert path %s is deprecated.", str(deprecated_path))
+                logging.warning("Please check https://github.com/URenko/Accesser/pull/245 for migration.")
                 return deprecated_path
             return decide_state_path_unix_like() / "CERT"
         case _:


### PR DESCRIPTION
在 #245 的基础上做了点小修补。修复了 #248。

- 将确定证书位置的部分移动到了 `setting.py`，让所有使用 `certpath` 的函数读取 `setting.certpath`。
- 将弃用的 `logging.warn` 替换成了 `logging.warning`。
- 将判断 root 用户的部分移动到了 `main` 函数的开始。
- 其它一些代码风格的小修改。